### PR TITLE
PR [1/3] remove superfluous menu entry

### DIFF
--- a/Shut Up/Views/Base.lproj/Main.storyboard
+++ b/Shut Up/Views/Base.lproj/Main.storyboard
@@ -176,13 +176,6 @@ CA
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Help" systemMenu="help" id="vue-SG-eLu">
                                     <items>
-                                        <menuItem title="Shut Up Help" id="FKE-Sm-Kum">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem isSeparatorItem="YES" id="hpf-HM-KvJ"/>
                                         <menuItem title="Contact Developer…" id="Xf9-yc-blb">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>

--- a/Shut Up/Views/mul.lproj/Main.xcstrings
+++ b/Shut Up/Views/mul.lproj/Main.xcstrings
@@ -415,24 +415,6 @@
         }
       }
     },
-    "FKE-Sm-Kum.title" : {
-      "comment" : "Class = \"NSMenuItem\"; title = \"Shut Up Help\"; ObjectID = \"FKE-Sm-Kum\";",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shut Up Hilfe"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Shut Up Help"
-          }
-        }
-      }
-    },
     "FQI-yB-DJR.title" : {
       "comment" : "Class = \"NSMenuItem\"; title = \"Redo\"; ObjectID = \"FQI-yB-DJR\";",
       "extractionState" : "extracted_with_value",


### PR DESCRIPTION
Since we do not provide a built-in help, “Shut Up Help” has been removed.