### PR TITLE
import Foundation instead of Cocoa where possible

### DIFF
--- a/Shared/Crypto.swift
+++ b/Shared/Crypto.swift
@@ -6,7 +6,6 @@
 //  See LICENSE.md for license information.
 //
 
-import Cocoa
 import Foundation
 import OSLog
 

--- a/Shared/EncryptedFile.swift
+++ b/Shared/EncryptedFile.swift
@@ -6,7 +6,7 @@
 //  See LICENSE.md for license information.
 //
 
-import Cocoa
+import Foundation
 
 final class EncryptedFile {
     let fsLocation: URL

--- a/Shared/Info.swift
+++ b/Shared/Info.swift
@@ -6,7 +6,7 @@
 //  See LICENSE.md for license information.
 //
 
-import Cocoa
+import Foundation
 
 enum Info {
     static let containingBundleId = "com.rickyromero.shutup" // WORKAROUND: Can't determine programmatically

--- a/Shared/Whitelist.swift
+++ b/Shared/Whitelist.swift
@@ -6,7 +6,7 @@
 //  See LICENSE.md for license information.
 //
 
-import Cocoa
+import Foundation
 
 class Whitelist {
     static var main = Whitelist()


### PR DESCRIPTION
This is more of a preparation for a long-term goal. I wondered whether we could make the app multiplatform (iOS, iPadOS, macOS). To do so, as much shared code should rely on Foundation instead of Cocoa, since Cocoa is only available on macOS.

There won't be any functional changes.